### PR TITLE
Default QBITTORRENT_SERVER to localhost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN sed -i "/${LANG}/s/^# //g" /etc/locale.gen && \
     ln -fs "/usr/share/zoneinfo/${TZ}" /etc/localtime && \
     dpkg-reconfigure tzdata
 
-ENV QBITTORRENT_SERVER=
+ENV QBITTORRENT_SERVER=localhost
 ENV QBITTORRENT_PORT=8080
 ENV QBITTORRENT_USER=admin
 ENV QBITTORRENT_PASS=adminadmin

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ These actions are performed continuously (in a loop, every 5 minutes (default, c
 
 ## Configurable variables:
 
-* QBITTORRENT_SERVER (Defaults to empty, **needs to be set**)
+* QBITTORRENT_SERVER (Defaults to **localhost**)
     * If setting here an address not related to the `VPN_IF_NAME` (default: tun0) a few users have [reported](https://old.reddit.com/r/ProtonVPN/comments/11ubgvi/port_forward_with_qbittorrent_and_protonvpn_on/jcxirts/) needing to set `FIREWALL_OUTBOUND_SUBNETS` for the Gluetun/VPN container
     * For ProtonVPN using Wireguard and qBittorrent container using `VPN_CT_NAME` as network_mode this would be set to **10.2.0.2**
 * QBITTORRENT_PORT (Defaults to **8080**)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
       - TZ=Etc/UTC
-      - QBITTORRENT_SERVER=
+      # - QBITTORRENT_SERVER=
       # - QBITTORRENT_PORT=8080
       # - QBITTORRENT_USER=admin
       # - QBITTORRENT_PASS=adminadmin


### PR DESCRIPTION
Just a small update that defaults QBITTORRENT_SERVER to localhost.
With the example config, both qbittorrent and qbittorrent-natmap use the gluetun container as network mode. Therefore they share the same virtual host and qbittorrent-natmap can reach qbittorrent via localhost. Defaulting it to localhost saves some time when figuring out the config.

This was tested with gluetun connected to ProtonVPN via OpenVPN (can't test WireGuard as it doesn't want to work properly with wsl).