### PR TITLE
👽️ implemented fix outlined in https://github.com/soxfor/qbittorrent-natmap/issues/23#issue-2279241745

### DIFF
--- a/data/start.sh
+++ b/data/start.sh
@@ -79,20 +79,20 @@ qbt_isreachable(){
 }
 
 fw_delrule(){
-    if (docker exec "${VPN_CT_NAME}" /sbin/iptables-legacy -L INPUT -n | grep -qP "^ACCEPT.*${configured_port}.*"); then
+    if (docker exec "${VPN_CT_NAME}" /sbin/iptables-nft -L INPUT -n | grep -qP "^ACCEPT.*${configured_port}.*"); then
         # shellcheck disable=SC2086
-        docker exec "${VPN_CT_NAME}" /sbin/iptables-legacy -D INPUT -i "${VPN_IF_NAME}" -p tcp --dport ${configured_port} -j ACCEPT
+        docker exec "${VPN_CT_NAME}" /sbin/iptables-nft -D INPUT -i "${VPN_IF_NAME}" -p tcp --dport ${configured_port} -j ACCEPT
         # shellcheck disable=SC2086
-        docker exec "${VPN_CT_NAME}" /sbin/iptables-legacy -D INPUT -i "${VPN_IF_NAME}" -p udp --dport ${configured_port} -j ACCEPT
+        docker exec "${VPN_CT_NAME}" /sbin/iptables-nft -D INPUT -i "${VPN_IF_NAME}" -p udp --dport ${configured_port} -j ACCEPT
     fi
 }
 
 fw_addrule(){
-    if ! (docker exec "${VPN_CT_NAME}" /sbin/iptables-legacy -L INPUT -n | grep -qP "^ACCEPT.*${active_port}.*"); then
+    if ! (docker exec "${VPN_CT_NAME}" /sbin/iptables-nft -L INPUT -n | grep -qP "^ACCEPT.*${active_port}.*"); then
         # shellcheck disable=SC2086
-        docker exec "${VPN_CT_NAME}" /sbin/iptables-legacy -A INPUT -i "${VPN_IF_NAME}" -p tcp --dport ${active_port} -j ACCEPT
+        docker exec "${VPN_CT_NAME}" /sbin/iptables-nft -A INPUT -i "${VPN_IF_NAME}" -p tcp --dport ${active_port} -j ACCEPT
         # shellcheck disable=SC2086
-        docker exec "${VPN_CT_NAME}" /sbin/iptables-legacy -A INPUT -i "${VPN_IF_NAME}" -p udp --dport ${active_port} -j ACCEPT
+        docker exec "${VPN_CT_NAME}" /sbin/iptables-nft -A INPUT -i "${VPN_IF_NAME}" -p udp --dport ${active_port} -j ACCEPT
         return 0
     else
         return 1


### PR DESCRIPTION
Fixes breaking changes introduced in gluetun releases since [3.39.0](https://github.com/qdm12/gluetun/releases/tag/v3.39.0). Updated references to deprecated `iptables` binary with `iptables-nft` to maintain compatibility with gluetun containers based on `alpine>=3.20`.  `iptables-nft` is the recommended as a drop-in substitute for `iptables` (rather than `iptables-legacy`).  